### PR TITLE
Use base64 for integrity hashes

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ type Config struct {
 
 // Default configuration for [HashedFS].
 var ConfigDefault = Config{
-	Hasher:            Sha256Hasher{},
+	Hasher:            Sha256Hasher,
 	Renamer:           ExtensionRenamer,
 	AllowedExtensions: []string{"js", "json", "png", "bmp", "jpeg", "jpg", "css", "ico"},
 }

--- a/doc_test.go
+++ b/doc_test.go
@@ -32,7 +32,7 @@ func Example_configured() {
 		// Extensions not in this list will not be given content-hashes
 		AllowedExtensions: []string{"css", "txt"},
 		// Mechanism to control the hash
-		Hasher: Crc32Hasher{},
+		Hasher: Crc32Hasher,
 		// Mechanism to control the naming of the content-hashed files
 		Renamer: FullNameRenamer,
 	})

--- a/fs_test.go
+++ b/fs_test.go
@@ -16,7 +16,7 @@ var testHashEmbedOptions *HashedFS
 func init() {
 	testHashEmbed, _ = Generate(testEmbed)
 	testHashEmbedOptions, _ = Generate(testEmbed, Config{
-		Hasher:  Crc32Hasher{},
+		Hasher:  Crc32Hasher,
 		Renamer: FullNameRenamer,
 	})
 }
@@ -36,18 +36,18 @@ func TestGetHashedPath(t *testing.T) {
 	)
 }
 
-func TestGetHash(t *testing.T) {
+func TestGetIntegrity(t *testing.T) {
 	assert.Equal(
 		t,
-		"8d77f04c3be2abcd554f262130ba6c30f277318e66588b6a0d95f476c4ae7c48",
-		testHashEmbedOptions.GetHash("testdata/test.css"),
-		"GetHash should be calculated correctly",
+		"jXfwTDviq81VTyYhMLpsMPJ3MY5mWItqDZX0dsSufEg=",
+		testHashEmbedOptions.GetIntegrity("testdata/test.css"),
+		"GetIntegrity should be calculated correctly",
 	)
 	assert.Equal(
 		t,
 		"",
-		testHashEmbedOptions.GetHash("testdata/fake.txt"),
-		"GetHash be blank when file does not exist",
+		testHashEmbedOptions.GetIntegrity("testdata/fake.txt"),
+		"GetIntegrity be blank when file does not exist",
 	)
 }
 

--- a/hash.go
+++ b/hash.go
@@ -8,35 +8,16 @@ import (
 )
 
 // Interface for a FileHasher.
-type FileHasher interface {
-	Algorithm() string
-	Hash(data []byte) (string, error)
-}
-
-// Sha256 Hasher.
-type Sha256Hasher struct{}
-
-// Return the algorithm name.
-func (h Sha256Hasher) Algorithm() string {
-	return "sha256"
-}
+type FileHasher = func(data []byte) (string, error)
 
 // Generate a hash for the data using SHA-256.
-func (h Sha256Hasher) Hash(data []byte) (string, error) {
+func Sha256Hasher(data []byte) (string, error) {
 	hash := sha256.New()
 	hash.Write(data)
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-// Crc32 Hasher.
-type Crc32Hasher struct{}
-
-// Return the algorithm name.
-func (h Crc32Hasher) Algorithm() string {
-	return "crc32"
-}
-
 // Generate a hash for the data using IEEE CRC 32.
-func (h Crc32Hasher) Hash(data []byte) (string, error) {
+func Crc32Hasher(data []byte) (string, error) {
 	return strconv.FormatUint(uint64(crc32.ChecksumIEEE(data)), 16), nil
 }

--- a/hash_test.go
+++ b/hash_test.go
@@ -7,35 +7,21 @@ import (
 )
 
 func TestSha256Hasher(t *testing.T) {
-	hasher := Sha256Hasher{}
-	hash, _ := hasher.Hash([]byte("test"))
+	hash, _ := Sha256Hasher([]byte("test"))
 	assert.Equal(
 		t,
 		"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 		hash,
 		"sha256 should be calculated correctly",
 	)
-	assert.Equal(
-		t,
-		"sha256",
-		hasher.Algorithm(),
-		"sha256 should be the algorithm",
-	)
 }
 
 func TestCrc32Hasher(t *testing.T) {
-	hasher := Crc32Hasher{}
-	hash, _ := hasher.Hash([]byte("test"))
+	hash, _ := Crc32Hasher([]byte("test"))
 	assert.Equal(
 		t,
 		"d87f7e0c",
 		hash,
 		"crc32 should be calculated correctly",
-	)
-	assert.Equal(
-		t,
-		"crc32",
-		hasher.Algorithm(),
-		"crc32 should be the algorithm",
 	)
 }


### PR DESCRIPTION
- SRI should be base64 encoded value
- Switch to previous FileHasher interface