### PR TITLE
Generalize HashedFS to work with any fs.FS, not just embed.FS

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -30,15 +30,14 @@ package hashembed
 
 import (
 	"crypto/sha256"
-	"embed"
 	"encoding/base64"
 	"io/fs"
 	"slices"
 )
 
-// HashedFS is an [embed.FS] with support for reading files with virtual content hashes embedded in the file name.
+// HashedFS is an [fs.FS] with support for reading files with virtual content hashes embedded in the file name.
 type HashedFS struct {
-	fs               embed.FS          // underlying embed.FS
+	fs               fs.FS             // underlying fs.FS
 	actualPathLookup map[string]string // lookups for the hashed path => actual path
 	hashedPathLookup map[string]string // lookups for the actual path => hashed path
 	integrityLookup  map[string]string // lookups for the actual path => integrity hash (sha-256)
@@ -59,7 +58,7 @@ func (f HashedFS) initializeFile(file PathedDirEntry) error {
 		return nil
 	}
 
-	data, err := f.fs.ReadFile(file.FullPath())
+	data, err := fs.ReadFile(f.fs, file.FullPath())
 	if err != nil {
 		return err
 	}
@@ -84,7 +83,7 @@ func (f HashedFS) initializeFile(file PathedDirEntry) error {
 // Initialize a path (could be file or directory) within the embed.FS.
 func (f HashedFS) initializePath(root PathedDirEntry) error {
 	rootPath := root.FullPath()
-	entries, err := f.fs.ReadDir(rootPath)
+	entries, err := fs.ReadDir(f.fs, rootPath)
 	if err != nil {
 		return err
 	}
@@ -106,7 +105,7 @@ func (f HashedFS) initializePath(root PathedDirEntry) error {
 
 // Initialize the [HashedFS] by iterating over the files in the embed.FS.
 func (f HashedFS) initialize() error {
-	entries, err := f.fs.ReadDir(".")
+	entries, err := fs.ReadDir(f.fs, ".")
 	if err != nil {
 		return err
 	}
@@ -121,7 +120,7 @@ func (f HashedFS) initialize() error {
 }
 
 // Generate will create a new instance of [HashedFS] using [Config] (if provided) or [ConfigDefault] if not provided.
-func Generate(fs embed.FS, cfgs ...Config) (*HashedFS, error) {
+func Generate(fsys fs.FS, cfgs ...Config) (*HashedFS, error) {
 	cfg := ConfigDefault
 	if len(cfgs) > 0 {
 		cfg = cfgs[0]
@@ -140,14 +139,16 @@ func Generate(fs embed.FS, cfgs ...Config) (*HashedFS, error) {
 	}
 
 	hashedEmbed := &HashedFS{
-		fs:               fs,
+		fs:               fsys,
 		actualPathLookup: make(map[string]string),
 		hashedPathLookup: make(map[string]string),
 		integrityLookup:  make(map[string]string),
 		cfg:              cfg,
 	}
 
-	hashedEmbed.initialize()
+	if err := hashedEmbed.initialize(); err != nil {
+		return nil, err
+	}
 	return hashedEmbed, nil
 }
 
@@ -190,16 +191,16 @@ func (f HashedFS) Open(name string) (fs.File, error) {
 	return f.fs.Open(f.GetActualPath(name))
 }
 
-// See [embed.FS.ReadDir]
+// See [fs.ReadDir]
 //
-// Note: This will only return files that actually exist in the [embed.FS] - hashed files are "virtual"
+// Note: This will only return files that actually exist in the underlying [fs.FS] - hashed files are "virtual"
 func (f HashedFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return f.fs.ReadDir(name)
+	return fs.ReadDir(f.fs, name)
 }
 
-// See [embed.FS]
+// See [fs.ReadFile]
 //
 // This will call [HashedFS.GetActualPath] on the file to get the correct name.
 func (f HashedFS) ReadFile(name string) ([]byte, error) {
-	return f.fs.ReadFile(f.GetActualPath(name))
+	return fs.ReadFile(f.fs, f.GetActualPath(name))
 }

--- a/fs.go
+++ b/fs.go
@@ -69,10 +69,6 @@ func (f HashedFS) initializeFile(file PathedDirEntry) error {
 	}
 
 	hashedPath := f.cfg.Renamer(file, hash)
-	if err != nil {
-		return err
-	}
-
 	fullPath := file.FullPath()
 	f.actualPathLookup[hashedPath] = fullPath
 	f.hashedPathLookup[fullPath] = hashedPath

--- a/fs_test.go
+++ b/fs_test.go
@@ -50,6 +50,23 @@ func (f subdirFailFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return nil, errors.New("subdir read error")
 }
 
+// nestedSubdirFailFS wraps a MapFS but returns an error from ReadDir for a specific path.
+type nestedSubdirFailFS struct {
+	inner      fstest.MapFS
+	failedPath string
+}
+
+func (f nestedSubdirFailFS) Open(name string) (fs.File, error) {
+	return f.inner.Open(name)
+}
+
+func (f nestedSubdirFailFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == f.failedPath {
+		return nil, errors.New("nested subdir read error")
+	}
+	return f.inner.ReadDir(name)
+}
+
 //go:embed testdata/*
 var testEmbed embed.FS
 
@@ -231,6 +248,36 @@ func TestGenerateHasherError(t *testing.T) {
 		},
 	})
 	assert.NotNil(t, err, "Generate should return an error when the Hasher fails")
+}
+
+func TestGenerateNilHasher(t *testing.T) {
+	hfs, err := Generate(testEmbed, Config{Renamer: FullNameRenamer})
+	assert.Nil(t, err, "Generate should not error when Hasher is nil (defaults to Sha256Hasher)")
+	assert.NotNil(t, hfs)
+}
+
+func TestInitializePathRecursiveError(t *testing.T) {
+	inner := fstest.MapFS{
+		"folder/subfolder/test.css": &fstest.MapFile{Data: []byte("body {}")},
+	}
+	_, err := Generate(nestedSubdirFailFS{inner: inner, failedPath: "folder/subfolder"})
+	assert.NotNil(t, err, "Generate should return an error when a nested subdirectory ReadDir fails")
+}
+
+func TestPathedDirEntry(t *testing.T) {
+	inner := fstest.MapFS{
+		"subdir/test.css": &fstest.MapFile{Data: []byte("body {}")},
+	}
+
+	rootEntries, err := fs.ReadDir(inner, ".")
+	assert.Nil(t, err)
+	dirEntry := NewPathedDirEntry(rootEntries[0], "")
+
+	assert.True(t, dirEntry.IsDir(), "PathedDirEntry.IsDir should return true for a directory")
+	assert.NotEqual(t, fs.FileMode(0), dirEntry.Type()&fs.ModeDir, "PathedDirEntry.Type should include ModeDir for a directory")
+	info, err := dirEntry.Info()
+	assert.Nil(t, err, "PathedDirEntry.Info should not error")
+	assert.Equal(t, "subdir", info.Name(), "PathedDirEntry.Info should return correct name")
 }
 
 func BenchmarkGenerate(b *testing.B) {

--- a/fs_test.go
+++ b/fs_test.go
@@ -2,10 +2,53 @@ package hashembed
 
 import (
 	"embed"
+	"errors"
+	"io/fs"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// failFS is an fs.FS whose Open always returns an error.
+type failFS struct{}
+
+func (f failFS) Open(name string) (fs.File, error) {
+	return nil, errors.New("open error")
+}
+
+// readFileErrFS wraps a MapFS but returns an error from ReadFile.
+type readFileErrFS struct {
+	inner fstest.MapFS
+}
+
+func (f readFileErrFS) Open(name string) (fs.File, error) {
+	return f.inner.Open(name)
+}
+
+func (f readFileErrFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return f.inner.ReadDir(name)
+}
+
+func (f readFileErrFS) ReadFile(name string) ([]byte, error) {
+	return nil, errors.New("read file error")
+}
+
+// subdirFailFS wraps a MapFS but returns an error from ReadDir for any path other than ".".
+type subdirFailFS struct {
+	inner fstest.MapFS
+}
+
+func (f subdirFailFS) Open(name string) (fs.File, error) {
+	return f.inner.Open(name)
+}
+
+func (f subdirFailFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == "." {
+		return f.inner.ReadDir(".")
+	}
+	return nil, errors.New("subdir read error")
+}
 
 //go:embed testdata/*
 var testEmbed embed.FS
@@ -155,6 +198,39 @@ func TestOpenFile(t *testing.T) {
 		stat.Name(),
 		"text.txt should be the name of the opened file",
 	)
+}
+
+func TestGenerateRootReadDirError(t *testing.T) {
+	_, err := Generate(failFS{})
+	assert.NotNil(t, err, "Generate should return an error when the root ReadDir fails")
+}
+
+func TestGenerateSubdirReadDirError(t *testing.T) {
+	inner := fstest.MapFS{
+		"subdir/test.css": &fstest.MapFile{Data: []byte("body {}")},
+	}
+	_, err := Generate(subdirFailFS{inner: inner})
+	assert.NotNil(t, err, "Generate should return an error when a subdirectory ReadDir fails")
+}
+
+func TestGenerateReadFileError(t *testing.T) {
+	inner := fstest.MapFS{
+		"subdir/test.css": &fstest.MapFile{Data: []byte("body {}")},
+	}
+	_, err := Generate(readFileErrFS{inner: inner})
+	assert.NotNil(t, err, "Generate should return an error when ReadFile fails")
+}
+
+func TestGenerateHasherError(t *testing.T) {
+	inner := fstest.MapFS{
+		"subdir/test.css": &fstest.MapFile{Data: []byte("body {}")},
+	}
+	_, err := Generate(inner, Config{
+		Hasher: func(data []byte) (string, error) {
+			return "", errors.New("hash error")
+		},
+	})
+	assert.NotNil(t, err, "Generate should return an error when the Hasher fails")
 }
 
 func BenchmarkGenerate(b *testing.B) {


### PR DESCRIPTION
## Summary
This PR refactors the `hashembed` package to work with any `fs.FS` implementation instead of being tightly coupled to `embed.FS`. This improves flexibility and testability while maintaining backward compatibility.

## Key Changes
- **Generalized API**: Changed `Generate()` function signature from accepting `embed.FS` to accepting `fs.FS`, allowing it to work with any filesystem implementation
- **Removed embed.FS dependency**: Removed the `embed` import from `fs.go` and replaced all `embed.FS` type references with `fs.FS`
- **Updated filesystem operations**: Changed direct method calls (`fs.ReadFile()`, `fs.ReadDir()`) to use the `fs` package functions, which work with any `fs.FS` implementation
- **Improved error handling**: Fixed the `Generate()` function to properly return errors from the `initialize()` method instead of silently ignoring them
- **Code cleanup**: Removed unreachable error handling code in `initializeFile()` that was checking for errors from the `Renamer` function (which doesn't return errors)

## Testing Improvements
Added comprehensive test coverage for error scenarios:
- Root directory read failures
- Subdirectory read failures
- File read failures
- Hasher function failures
- Nested subdirectory read failures
- New `PathedDirEntry` helper tests

These changes enable testing with mock filesystem implementations (like `fstest.MapFS`) and improve the overall robustness of the package.

https://claude.ai/code/session_01Rs2T91zrNpRNN57XVS71hC